### PR TITLE
Make London Upgrade capitalization consistent in "src/content/developers/docs/gas/index.md"

### DIFF
--- a/src/content/developers/docs/gas/index.md
+++ b/src/content/developers/docs/gas/index.md
@@ -22,7 +22,7 @@ _Diagram adapted from [Ethereum EVM illustrated](https://takenobu-hs.github.io/d
 
 Gas fees are paid in Ethereum's native currency, ether (ETH). Gas prices are denoted in gwei, which itself is a denomination of ETH - each gwei is equal to 0.000000001 ETH (10<sup>-9</sup> ETH). For example, instead of saying that your gas costs 0.000000001 ether, you can say your gas costs 1 gwei. The word 'gwei' itself means 'giga-wei', and it is equal to 1,000,000,000 wei. Wei itself (named after [Wei Dai](https://en.wikipedia.org/wiki/Wei_Dai), creator of [b-money](https://www.investopedia.com/terms/b/bmoney.asp)) is the smallest unit of ETH.
 
-## Prior to the London upgrade {#pre-london}
+## Prior to the London Upgrade {#pre-london}
 
 The way transaction fees on the Ethereum network are calculated changed during the London network upgrade. Here is a recap of how things used to work:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This makes it consistently "London Upgrade" in "src/content/developers/docs/gas/index.md"
## Description
This makes it consistently "London Upgrade" (in the headings).
<!--- Describe your changes in detail -->

## Related Issue
none
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
